### PR TITLE
Updated version to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ package-install Geodan.SensorThings.SDK
 Push new version:
 
 ```
-$ nuget push Geodan.SensorThings.SDK.0.2.3.nupkg -Source https://www.nuget.org/api/v2/package
+$ nuget push Geodan.SensorThings.SDK.0.3.0.nupkg -Source https://www.nuget.org/api/v2/package
 ```
 
 ### Sample applications

--- a/src/sensorthings-net-sdk/sensorthings-net-sdk.csproj
+++ b/src/sensorthings-net-sdk/sensorthings-net-sdk.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.2.3</Version>
+    <Version>0.3.0</Version>
     <PackageReleaseNotes />
     <Authors>Bert Temme</Authors>
   </PropertyGroup>


### PR DESCRIPTION
We should change the version and upload the package to NuGet because of the library changes (.NET Standard 2.0).